### PR TITLE
Added window check for server side rendering compatibility

### DIFF
--- a/src/GoalTracker.js
+++ b/src/GoalTracker.js
@@ -1,5 +1,5 @@
 var escapeStringRegexp = require('escape-string-regexp');
-var Sizzle = require('sizzle');
+var Sizzle = typeof window === 'undefined' ? function () {} : require('sizzle');
 
 function doesUrlMatch(matcher, href, search, hash) {
   var canonicalUrl = href.replace(search, '').replace(hash, '');


### PR DESCRIPTION
Sizzle needs the window object in order to work. However on the server side (during pre-rendering) window doesn't exist and so this check is required for universal apps to work.