### PR TITLE
Add guard around EventSource for browsers without support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.6] - 2016-08-23
+### Changed
+- Added check for EventSource before trying to connect Stream.
+
 ## [1.0.5] - 2016-08-22
 ### Changed
 - Fixed an error that occurred on `hashchage`/`popstate` if the account had no goals.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ This is the official LaunchDarkly client-side JavaScript SDK. This SDK does two 
 * Makes feature flags available to your client-side (front-end) JavaScript code.
 * Sends click, pageview, and custom events from your front-end for A/B tests and analytics.
 
+## Browser Support
+
+The LaunchDarkly client-side JavaScript SDK supports the following browsers:
+
+* Chrome (any recent)
+* Firefox (any recent)
+* Safari (any recent)*
+* Internet Explorer (IE10+)*
+* Edge (any recent)*
+* Opera (any recent)*
+
+\* These browsers do not support streaming new flags to connected clients, even when `client.on('change')` is called.
+
 ## Installation
 
 There are two ways to install the client-side SDK:
@@ -51,7 +64,7 @@ Out of the box, initializing the client will make a remote request to LaunchDark
 
 Bootstrapping refers to providing the LaunchDarkly client object with an initial, immediately available set of feature flag values so that on page load `variation` can be called with no delay.
 
-#### From the server-side SDK 
+#### From the server-side SDK
 
 The preferred approach to bootstrapping is to populate the bootstrap values (a map of feature flag keys to flag values) from your backend. LaunchDarkly's server-side SDKs have a function called `all_flags`-- this function provides the initial set of bootstrap values. You can then provide these values to your front-end as a template. Depending on your templating language, this might look something like this:
 
@@ -66,15 +79,15 @@ If you bootstrap from the server-side, feature flags will be ready immediately, 
 
 #### From Local Storage
 
-Alternatively, you can bootstrap feature flags from local storage. 
+Alternatively, you can bootstrap feature flags from local storage.
 
         var client = LDClient.initialize('YOUR_ENVIRONMENT_ID', user, options = {
           bootstrap: 'localStorage'
         });
 
-When using local storage, the client will store the latest flag settings in local storage. On page load, the previous settings will be used and the 'ready' event will be emitted immediately. This means that on page load, the user may see cached flag values until the next page load. 
+When using local storage, the client will store the latest flag settings in local storage. On page load, the previous settings will be used and the 'ready' event will be emitted immediately. This means that on page load, the user may see cached flag values until the next page load.
 
-You can still subscribe to flag changes if you're using local storage. 
+You can still subscribe to flag changes if you're using local storage.
 
 
 ### Secure mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -2,20 +2,22 @@ function Stream(url, environment) {
   var stream = {};
   var url = url + '/ping/' + environment;
   var es = null;
-  
+
   stream.connect = function(onPing) {
-    es = new EventSource(url);
-    es.addEventListener('ping', onPing);
+    if (typeof EventSource !== 'undefined') {
+      es = new window.EventSource(url);
+      es.addEventListener('ping', onPing);
+    }
   }
 
   stream.disconnect = function() {
-    es.close();
+    es && es.close();
   }
-  
+
   stream.isConnected = function() {
     return es && (es.readyState === EventSource.OPEN || es.readyState === EventSource.CONNECTING);
   }
-  
+
   return stream;
 }
 

--- a/src/__tests__/Stream-test.js
+++ b/src/__tests__/Stream-test.js
@@ -1,0 +1,25 @@
+var Stream = require('../Stream');
+
+var noop = function() {};
+
+describe('Stream', function() {
+  it('should not throw on EventSource when it does not exist', function() {
+    window.EventSource = undefined;
+    var stream = new Stream('https://example.com', 'test');
+
+    var connect = function() {
+      stream.connect(noop);
+    }
+
+    expect(connect).to.not.throw(TypeError);
+  });
+  it('should not throw when calling disconnect without first calling connect', function() {
+    var stream = new Stream('https://example.com', 'test');
+
+    var disconnect = function() {
+      stream.disconnect(noop);
+    }
+
+    expect(disconnect).to.not.throw(TypeError);
+  })
+});


### PR DESCRIPTION
# Problem

When running this script in Internet Explorer, MS Edge, Safari <9, etc, you get an error when utilizing the Streaming API, as these browsers don't have `EventSource` defined. See [caniuse](http://caniuse.com/#feat=eventsource) for more information.

In addition, this wasn't clear or obvious at all from the README.

# Proposed Solution

Obviously `EventSource` can be polyfilled (around ~25KB minified and gzipped with [eventsource](https://github.com/aslakhellesoy/eventsource) for example) but it seems safe and reasonable to just ignore streaming functionality in browsers without support (either native or through polyfill) for  `EventSource`.

The consumers of this client could also take special care to not use the Streaming API with non-compliant browsers, but this means the internal implementation of the client are leaked, not as future-proof, and arduous to implement/remember.

I added a simple test that checks things don't explode when `window.EventSource` is undefined.

I added an entry in the CHANGELOG, the README, and bumped the package version. Let me know if this is something you do at release time and I can revert the changes to package.json and CHANGELOG.

Thanks.