### PR TITLE
Add all_flags method to the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Out of the box, initializing the client will make a remote request to LaunchDark
 You can also fetch all feature flags for a user:
 
 
-          var flags = client.all_flags();
+          var flags = client.allFlags();
 
 This will return a key / value map of all your feature flags. The map will contain `null` values for any flags that would return the fallback value (the second argument that you normally pass to `variation`). Note that this will send analytics events to LaunchDarkly as if you'd called `variation` for every feature flag.
 
@@ -83,7 +83,7 @@ Bootstrapping refers to providing the LaunchDarkly client object with an initial
 
 #### From the server-side SDK
 
-The preferred approach to bootstrapping is to populate the bootstrap values (a map of feature flag keys to flag values) from your backend. LaunchDarkly's server-side SDKs have a function called `all_flags`-- this function provides the initial set of bootstrap values. You can then provide these values to your front-end as a template. Depending on your templating language, this might look something like this:
+The preferred approach to bootstrapping is to populate the bootstrap values (a map of feature flag keys to flag values) from your backend. LaunchDarkly's server-side SDKs have a function called `allFlags`-- this function provides the initial set of bootstrap values. You can then provide these values to your front-end as a template. Depending on your templating language, this might look something like this:
 
         var user = {key: 'user.example.com'};
         var client = LDClient.initialize('YOUR_ENVIRONMENT_ID', user, options = {

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Out of the box, initializing the client will make a remote request to LaunchDark
 
 *Note*: Feature flags must marked available to the client-side SDK (see your feature flag's settings page) before they can be used in variation calls on the front-end. If you request a feature flag that is not available, you'll receive the default value for that flag.
 
+You can also fetch all feature flags for a user:
+
+
+          var flags = client.all_flags();
+
+This will return a key / value map of all your feature flags. The map will contain `null` values for any flags that would return the fallback value (the second argument that you normally pass to `variation`). Note that this will send analytics events to LaunchDarkly as if you'd called `variation` for every feature flag.
 
 ### Bootstrapping
 

--- a/src/index.js
+++ b/src/index.js
@@ -99,6 +99,17 @@ function variation(key, defaultValue) {
   return value;
 }
 
+function all_flags() {
+  var results = {};
+  for (var key in flags) {
+    if (flags.hasOwnProperty(key)) {
+      results[key] = variation(key, null);
+    }
+  }
+
+  return results;
+}
+
 function track(key, data) {
   if (typeof key !== 'string') {
     throw 'Event key must be a string';
@@ -177,7 +188,8 @@ var client = {
   variation: variation,
   track: track,
   on: on,
-  off: off
+  off: off,
+  all_flags: all_flags
 };
 
 function lsKey(env, user) {

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ function variation(key, defaultValue) {
   return value;
 }
 
-function all_flags() {
+function allFlags() {
   var results = {};
   for (var key in flags) {
     if (flags.hasOwnProperty(key)) {
@@ -189,7 +189,7 @@ var client = {
   track: track,
   on: on,
   off: off,
-  all_flags: all_flags
+  allFlags: allFlags
 };
 
 function lsKey(env, user) {


### PR DESCRIPTION
This adds the all_flags method to the JS client. Unlike the server-side all_flags method, I've chosen to have this send analytics events. 

The server-side use case is to bootstrap flags, so it doesn't necessarily make sense to send events there. Here, I think there's a stronger argument for sending the events. We might possibly want to make it an option, though?