### PR TITLE
do not abort requests in requestor

### DIFF
--- a/src/Requestor.js
+++ b/src/Requestor.js
@@ -32,7 +32,7 @@ function Requestor(baseUrl, environment) {
   requestor.fetchFlagSettings = function(user, hash, callback) {
     var data = utils.base64URLEncode(JSON.stringify(user));
     var endpoint = [baseUrl, '/sdk/eval/', environment,  '/users/', data, hash ? '?h=' + hash : ''].join('');
-    var cb = callback;
+    var cb;
 
     if (flagSettingsRequest) {
       flagSettingsRequest.abort();

--- a/src/Requestor.js
+++ b/src/Requestor.js
@@ -23,20 +23,13 @@ function fetchJSON(endpoint, callback) {
   return xhr;
 }
 
-var flagSettingsRequest;
-
 function Requestor(baseUrl, environment) {
   var requestor = {};
   
   requestor.fetchFlagSettings = function(user, hash, callback) {
     var data = utils.base64URLEncode(JSON.stringify(user));
     var endpoint = [baseUrl, '/sdk/eval/', environment,  '/users/', data, hash ? '?h=' + hash : ''].join('');
-    
-    if (flagSettingsRequest) {
-      flagSettingsRequest.abort();
-    }
-    
-    flagSettingsRequest = fetchJSON(endpoint, callback);
+    fetchJSON(endpoint, callback);
   };
   
   requestor.fetchGoals = function(callback) {

--- a/src/__tests__/Requestor-test.js
+++ b/src/__tests__/Requestor-test.js
@@ -1,18 +1,33 @@
 var Requestor = require('../Requestor');
 
 describe('Requestor', function() {
-  it('should always call the callback', function(done) {
+  var server;
+  var seq = 0;
+
+  beforeEach(function() {
+    server = sinon.fakeServer.create();
+  });
+  
+  afterEach(function() {
+    server.restore();
+  });
+
+  it('should always call the callback', function() {
     const handleOne = sinon.spy();
     const handleTwo = sinon.spy();
+
     requestor = Requestor('http://requestee', 'FAKE_ENV');
+    requestor.fetchFlagSettings({key: 'user1'}, 'hash1', handleOne);
+    requestor.fetchFlagSettings({key: 'user2'}, 'hash2', handleTwo);
 
-    requestor.fetchFlagSettings({key: 'user'}, 'hash', handleOne);
-    requestor.fetchFlagSettings({key: 'user'}, 'hash', handleTwo);
+    server.respondWith(function(req) {
+      seq++;
+      req.respond(200, {'Content-type': 'application/json'}, JSON.stringify({tag: seq}));
+    });
 
-    setTimeout(function() {
-      expect(handleOne.called).to.be.true;
-      expect(handleTwo.called).to.be.true;
-      done();
-    }, 300);
+    server.respond();
+
+    expect(server.requests.length).to.equal(2);
+    expect(handleOne.args[0]).to.eql(handleTwo.args[0]);
   });
 });

--- a/src/__tests__/Requestor-test.js
+++ b/src/__tests__/Requestor-test.js
@@ -1,0 +1,18 @@
+var Requestor = require('../Requestor');
+
+describe('Requestor', function() {
+  it('should always call the callback', function(done) {
+    const handleOne = sinon.spy();
+    const handleTwo = sinon.spy();
+    requestor = Requestor('http://requestee', 'FAKE_ENV');
+
+    requestor.fetchFlagSettings({key: 'user'}, 'hash', handleOne);
+    requestor.fetchFlagSettings({key: 'user'}, 'hash', handleTwo);
+
+    setTimeout(function() {
+      expect(handleOne.called).to.be.true;
+      expect(handleTwo.called).to.be.true;
+      done();
+    }, 300);
+  });
+});


### PR DESCRIPTION
The way cancellation was implemented here meant that it was possible for callbacks to never be called because the associated request was cancelled. I don't see a reason to keep this code right now.