### PR TITLE
avoid calling callbacks more than once when queued

### DIFF
--- a/src/__tests__/Requestor-test.js
+++ b/src/__tests__/Requestor-test.js
@@ -30,4 +30,36 @@ describe('Requestor', function() {
     expect(server.requests.length).to.equal(2);
     expect(handleOne.args[0]).to.eql(handleTwo.args[0]);
   });
+
+  it('should call the each callback at most once', function() {
+    const handleOne = sinon.spy();
+    const handleTwo = sinon.spy();
+    const handleThree = sinon.spy();
+    const handleFour = sinon.spy();
+    const handleFive = sinon.spy();
+
+    server.respondWith(function(req) {
+      seq++;
+      req.respond(200, {'Content-type': 'application/json'}, JSON.stringify({tag: seq}));
+    });
+
+    requestor = Requestor('http://requestee', 'FAKE_ENV');
+    requestor.fetchFlagSettings({key: 'user1'}, 'hash1', handleOne);
+    server.respond();
+    requestor.fetchFlagSettings({key: 'user2'}, 'hash2', handleTwo);
+    server.respond();
+    requestor.fetchFlagSettings({key: 'user3'}, 'hash3', handleThree);
+    server.respond();
+    requestor.fetchFlagSettings({key: 'user4'}, 'hash4', handleFour);
+    server.respond();
+    requestor.fetchFlagSettings({key: 'user5'}, 'hash5', handleFive);
+    server.respond();
+
+    expect(server.requests.length).to.equal(5);
+    expect(handleOne.calledOnce).to.be.true;
+    expect(handleTwo.calledOnce).to.be.true;
+    expect(handleThree.calledOnce).to.be.true;
+    expect(handleFour.calledOnce).to.be.true;
+    expect(handleFive.calledOnce).to.be.true;
+  });
 });


### PR DESCRIPTION
I did some more testing before deploying to our CDN and noticed that the ready event was being called twice. This change ensures we only ever call each callback once.