### PR TITLE
Add support for client side camelCased keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "phantomjs": "1.9.18",
     "pretty-bytes": "3.0.1",
     "readline-sync": "1.4.4",
+    "rewire": "^2.5.2",
+    "rewire-webpack": "^1.0.1",
     "semver-compare": "^1.0.0",
     "sinon": "1.17.4",
     "webpack": "1.13.1"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "Base64": "1.0.0",
+    "dashify": "^0.2.2",
     "escape-string-regexp": "1.0.5",
     "sizzle": "2.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "Base64": "1.0.0",
-    "dashify": "^0.2.2",
     "escape-string-regexp": "1.0.5",
     "sizzle": "2.3.0"
   },

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -61,30 +61,60 @@ describe('LDClient', function() {
   });
 
   describe('variation', function() {
-    it('should return value for specified dashed-separated key', function(done) {
-      var user = {key: 'user'};
-      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
-        bootstrap: {'this-is-a-test-key': true}
+    it('should return value for dashed-separated key', function(done) {
+      const user = {key: 'user'};
+      const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': true}
       });
 
       client.on('ready', function(){
-        var dashedKey = 'this-is-a-test-key';
-        var flagValue = client.variation(dashedKey, false);
+        const dashedKey = 'this-is-a-test-key';
+        const flagValue = client.variation(dashedKey, false);
+        expect(flagValue).to.eq('protein');
+        done();
+      });
+    });
+
+    it('should return value for camelCased key', function(done) {
+      const user = {key: 'user'};
+      const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': true, 'some-other-key': 'muscle'}
+      });
+
+      client.on('ready', function(){
+        const camelCasedKey = 'thisIsATestKey';
+        const flagValue = client.variation(camelCasedKey, false);
         expect(flagValue).to.be.true;
         done();
       });
     });
 
-    it.only('should return value for specified camelCased key', function(done) {
-      var user = {key: 'user'};
-      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
-        bootstrap: {'this-is-a-test-key': true}
+    it('should return default value for non-existent dashed key', function(done) {
+      const user = {key: 'user'};
+      const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': 'bar'}
       });
 
       client.on('ready', function(){
-        var camelCasedKey = 'thisIsATestKey'; // this fails, it becomes this-is-atest
-        var flagValue = client.variation(camelCasedKey, false);
-        expect(flagValue).to.be.true;
+        const defaultValue = 'cabbage';
+        const key = 'does-not-exist';
+        const flagValue = client.variation(key, defaultValue);
+        expect(flagValue).to.eq(defaultValue);
+        done();
+      });
+    });
+
+    it('should return default value for non-existent camelCased key', function(done) {
+      const user = {key: 'user'};
+      const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': 'bar'}
+      });
+
+      client.on('ready', function(){
+        const defaultValue = 'cabbage';
+        const key = 'doesNotExist';
+        const flagValue = client.variation(key, defaultValue);
+        expect(flagValue).to.eq(defaultValue);
         done();
       });
     });

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -4,23 +4,23 @@ var semverCompare = require('semver-compare');
 describe('LDClient', function() {
   var xhr;
   var requests = [];
-  
+
   beforeEach(function() {
     xhr = sinon.useFakeXMLHttpRequest();
     xhr.onCreate = function(req) {
       requests.push(req);
     };
   });
-  
+
   afterEach(function() {
     requests = [];
     xhr.restore();
   });
-  
+
   it('should exist', function() {
     expect(LDClient).to.exist;
   });
-  
+
   describe('initialization', function() {
     it('should trigger the ready event', function(done) {
       var user = {key: 'user'};
@@ -28,21 +28,21 @@ describe('LDClient', function() {
       var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {}
       });
-      
+
       client.on('ready', handleReady);
-      
+
       setTimeout(function() {
         expect(handleReady.called).to.be.true;
         done();
       }, 0);
     });
-    
+
     it('should not fetch flag settings since bootstrap is provided', function() {
       var user = {key: 'user'};
       var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {}
       });
-      
+
       var settingsRequest = requests[0];
       expect(/sdk\/eval/.test(settingsRequest.url)).to.be.false;
     });
@@ -59,5 +59,35 @@ describe('LDClient', function() {
       expect(result).to.equal(1);
     });
   });
-  
+
+  describe('variation', function() {
+    it('should return value for specified dashed-separated key', function(done) {
+      var user = {key: 'user'};
+      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': true}
+      });
+
+      client.on('ready', function(){
+        var dashedKey = 'this-is-a-test-key';
+        var flagValue = client.variation(dashedKey, false);
+        expect(flagValue).to.be.true;
+        done();
+      });
+    });
+
+    it.only('should return value for specified camelCased key', function(done) {
+      var user = {key: 'user'};
+      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': true}
+      });
+
+      client.on('ready', function(){
+        var camelCasedKey = 'thisIsATestKey'; // this fails, it becomes this-is-atest
+        var flagValue = client.variation(camelCasedKey, false);
+        expect(flagValue).to.be.true;
+        done();
+      });
+    });
+  });
+
 });

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -1,28 +1,28 @@
 var LDClient = require('../index');
 var semverCompare = require('semver-compare');
 
-describe('LDClient', function() {
+describe('LDClient', function () {
   var xhr;
   var requests = [];
 
-  beforeEach(function() {
+  beforeEach(function () {
     xhr = sinon.useFakeXMLHttpRequest();
-    xhr.onCreate = function(req) {
+    xhr.onCreate = function (req) {
       requests.push(req);
     };
   });
 
-  afterEach(function() {
+  afterEach(function () {
     requests = [];
     xhr.restore();
   });
 
-  it('should exist', function() {
+  it('should exist', function () {
     expect(LDClient).to.exist;
   });
 
-  describe('initialization', function() {
-    it('should trigger the ready event', function(done) {
+  describe('initialization', function () {
+    it('should trigger the ready event', function (done) {
       var user = {key: 'user'};
       var handleReady = sinon.spy();
       var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
@@ -31,13 +31,13 @@ describe('LDClient', function() {
 
       client.on('ready', handleReady);
 
-      setTimeout(function() {
+      setTimeout(function () {
         expect(handleReady.called).to.be.true;
         done();
       }, 0);
     });
 
-    it('should not fetch flag settings since bootstrap is provided', function() {
+    it('should not fetch flag settings since bootstrap is provided', function () {
       var user = {key: 'user'};
       var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {}
@@ -60,14 +60,14 @@ describe('LDClient', function() {
     });
   });
 
-  describe('variation', function() {
-    it('should return value for dashed-separated key', function(done) {
+  describe('variation', function () {
+    it('should return value for dashed-separated key', function (done) {
       const user = {key: 'user'};
       const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': true}
       });
 
-      client.on('ready', function(){
+      client.on('ready', function () {
         const dashedKey = 'this-is-a-test-key';
         const flagValue = client.variation(dashedKey, false);
         expect(flagValue).to.eq('protein');
@@ -75,13 +75,13 @@ describe('LDClient', function() {
       });
     });
 
-    it('should return value for camelCased key', function(done) {
+    it('should return value for camelCased key', function (done) {
       const user = {key: 'user'};
       const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {'this-is-a-test-key': true, 'some-other-key': 'muscle'}
       });
 
-      client.on('ready', function(){
+      client.on('ready', function () {
         const camelCasedKey = 'thisIsATestKey';
         const flagValue = client.variation(camelCasedKey, false);
         expect(flagValue).to.be.true;
@@ -89,13 +89,13 @@ describe('LDClient', function() {
       });
     });
 
-    it('should return default value for non-existent dashed key', function(done) {
+    it('should return default value for non-existent dashed key', function (done) {
       const user = {key: 'user'};
       const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': 'bar'}
       });
 
-      client.on('ready', function(){
+      client.on('ready', function () {
         const defaultValue = 'cabbage';
         const key = 'does-not-exist';
         const flagValue = client.variation(key, defaultValue);
@@ -104,13 +104,13 @@ describe('LDClient', function() {
       });
     });
 
-    it('should return default value for non-existent camelCased key', function(done) {
+    it('should return default value for non-existent camelCased key', function (done) {
       const user = {key: 'user'};
       const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': 'bar'}
       });
 
-      client.on('ready', function(){
+      client.on('ready', function () {
         const defaultValue = 'cabbage';
         const key = 'doesNotExist';
         const flagValue = client.variation(key, defaultValue);
@@ -120,4 +120,20 @@ describe('LDClient', function() {
     });
   });
 
+  describe('on subscribe to change event', function () {
+    it('should correctly subscribe to change event using camelCased key', function (done) {
+
+      // TODO: rewire require('./EventEmitter'); so we can check that emitter.on is called
+      // with the correct event name (line 203 index.js)
+      const user = {key: 'user'};
+      const client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {'this-is-a-test-key': 'protein', 'some-other-key': true}
+      });
+
+      client.on('ready', function () {
+        client.on('change:thisIsATestKey');
+        done();
+      });
+    });
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ var Stream = require('./Stream');
 var Requestor = require('./Requestor');
 var Identity = require('./Identity');
 var utils = require('./utils');
+var dashify = require('dashify');
 
 var flags = {};
 var environment;
@@ -85,17 +86,23 @@ function identify(user, hash, onDone) {
   });
 }
 
+/**
+ * Retrieve a flag value for a given key from in-memory cache populated by initialize method
+ * @param key Retrieve value for this key. Can be of two formats: all-low-caps-dash-separated or camelCased
+ * @param defaultValue Use this value if flag does not exist in memory
+ * @returns {*} The value of the flag specified by key
+ */
 function variation(key, defaultValue) {
   var value;
+  var dashSeparatedKey = dashify(key);
   
-  if (flags.hasOwnProperty(key)) {
-    value = flags[key] === null ? defaultValue : flags[key];
+  if (flags.hasOwnProperty(dashSeparatedKey)) {
+    value = flags[dashSeparatedKey] === null ? defaultValue : flags[dashSeparatedKey];
   } else {
     value = defaultValue;
   }
   
-  sendFlagEvent(key, value, defaultValue);
-  
+  sendFlagEvent(dashSeparatedKey, value, defaultValue);
   return value;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ function identify(user, hash, onDone) {
 function variation(key, defaultValue) {
   var value;
   var dashSeparatedKey = dashify(key);
-  
+
   if (flags.hasOwnProperty(dashSeparatedKey)) {
     value = flags[dashSeparatedKey] === null ? defaultValue : flags[dashSeparatedKey];
   } else {

--- a/src/index.js
+++ b/src/index.js
@@ -68,17 +68,17 @@ function sendGoalEvent(kind, goal) {
     url: window.location.href,
     creationDate: (new Date()).getTime()
   };
-  
+
   if (kind === 'click') {
     event.selector = goal.selector;
   }
-  
+
   return events.enqueue(event);
 }
 
 function identify(user, hash, onDone) {
   ident.setUser(user);
-  requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
+  requestor.fetchFlagSettings(ident.getUser(), hash, function (err, settings) {
     if (settings) {
       updateSettings(settings);
     }
@@ -86,24 +86,36 @@ function identify(user, hash, onDone) {
   });
 }
 
+function removeDashes(s) {
+  return s.replace(/-/g, '');
+}
+
 /**
- * Retrieve a flag value for a given key from in-memory cache populated by initialize method
+ * Retrieve a flag value for a given key from in-memory cache populated by initialize method.
  * @param key Retrieve value for this key. Can be of two formats: all-low-caps-dash-separated or camelCased
  * @param defaultValue Use this value if flag does not exist in memory
  * @returns {*} The value of the flag specified by key
  */
 function variation(key, defaultValue) {
-  var value;
-  var dashSeparatedKey = dashify(key);
-
-  if (flags.hasOwnProperty(dashSeparatedKey)) {
-    value = flags[dashSeparatedKey] === null ? defaultValue : flags[dashSeparatedKey];
-  } else {
-    value = defaultValue;
+  // transform keys into all lower case without dashes
+  var strippedLoweredKey = key.toLowerCase();
+  if(key.includes('-')) {
+    strippedLoweredKey = removeDashes(strippedLoweredKey);
   }
-  
-  sendFlagEvent(dashSeparatedKey, value, defaultValue);
-  return value;
+
+  // the keys in memory from the server are already in lower case,
+  // so we just need to strip dashes
+  for(const dashedKey in flags) {
+    if(removeDashes(dashedKey) === strippedLoweredKey) {
+      var value = flags[dashedKey] ? flags[dashedKey] : defaultValue;
+      sendFlagEvent(dashedKey, value, defaultValue);
+      return value;
+    }
+  }
+
+  // key not found
+  sendFlagEvent(key, defaultValue, defaultValue);
+  return defaultValue;
 }
 
 function allFlags() {
@@ -121,7 +133,7 @@ function track(key, data) {
   if (typeof key !== 'string') {
     throw 'Event key must be a string';
   }
-  
+
   events.enqueue({
     kind: 'custom',
     key: key,
@@ -132,8 +144,8 @@ function track(key, data) {
 }
 
 function connectStream() {
-  stream.connect(function() {
-    requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
+  stream.connect(function () {
+    requestor.fetchFlagSettings(ident.getUser(), hash, function (err, settings) {
       updateSettings(settings);
     });
   });
@@ -142,7 +154,7 @@ function connectStream() {
 function updateSettings(settings) {
   var changes = utils.modifications(flags, settings);
   var keys = Object.keys(changes);
-  
+
   flags = settings;
 
   if (useLocalStorage) {
@@ -150,13 +162,13 @@ function updateSettings(settings) {
   }
 
   if (keys.length > 0) {
-    keys.forEach(function(key) {
+    keys.forEach(function (key) {
       emitter.emit(changeEvent + ':' + key, changes[key].current, changes[key].previous);
     });
 
     emitter.emit(changeEvent, changes);
-    
-    keys.forEach(function(key) {
+
+    keys.forEach(function (key) {
       sendFlagEvent(key, changes[key].current);
     });
   }
@@ -178,7 +190,9 @@ function off() {
 }
 
 function handleMessage(event) {
-  if (event.origin !== baseUrl) { return; }
+  if (event.origin !== baseUrl) {
+    return;
+  }
   if (event.data.type === 'SYN') {
     window.editorClientBaseUrl = baseUrl;
     var editorTag = document.createElement('script');
@@ -220,18 +234,20 @@ function initialize(env, user, options) {
   emitter = EventEmitter();
   ident = Identity(user, sendIdentifyEvent);
   requestor = Requestor(baseUrl, environment);
-  
+
   if (typeof options.bootstrap === 'object') {
     // Emitting the event here will happen before the consumer
     // can register a listener, so defer to next tick.
-    setTimeout(function() { emitter.emit(readyEvent); }, 0);
-  } 
+    setTimeout(function () {
+      emitter.emit(readyEvent);
+    }, 0);
+  }
   else if (typeof(options.bootstrap) === 'string' && options.bootstrap.toUpperCase() === 'LOCALSTORAGE' && typeof(Storage) !== 'undefined') {
     useLocalStorage = true;
     flags = JSON.parse(localStorage.getItem(lsKey(environment, ident.getUser())));
 
     if (flags === null) {
-      requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
+      requestor.fetchFlagSettings(ident.getUser(), hash, function (err, settings) {
         flags = settings;
         localStorage.setItem(lsKey(environment, ident.getUser()), JSON.stringify(flags));
         emitter.emit(readyEvent);
@@ -240,27 +256,30 @@ function initialize(env, user, options) {
       // We're reading the flags from local storage. Signal that we're ready,
       // then update localStorage for the next page load. We won't signal changes or update
       // the in-memory flags unless you subscribe for changes
-      setTimeout(function() { emitter.emit(readyEvent); }, 0);
-      requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
+      setTimeout(function () {
+        emitter.emit(readyEvent);
+      }, 0);
+      requestor.fetchFlagSettings(ident.getUser(), hash, function (err, settings) {
         localStorage.setItem(lsKey(environment, ident.getUser()), JSON.stringify(settings));
       });
     }
   }
   else {
-    requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
+    requestor.fetchFlagSettings(ident.getUser(), hash, function (err, settings) {
       flags = settings;
       emitter.emit(readyEvent);
     });
   }
-  
-  requestor.fetchGoals(function(err, g) {
-    if (err) {/* TODO */}
+
+  requestor.fetchGoals(function (err, g) {
+    if (err) {/* TODO */
+    }
     if (g && g.length > 0) {
       goals = g;
       goalTracker = GoalTracker(goals, sendGoalEvent);
     }
   });
-  
+
   function start() {
     setTimeout(function tick() {
       events.flush(ident.getUser());
@@ -273,23 +292,23 @@ function initialize(env, user, options) {
   } else {
     start();
   }
-  
-  window.addEventListener('beforeunload', function() {
+
+  window.addEventListener('beforeunload', function () {
     events.flush(ident.getUser(), true);
   });
-  
+
   function refreshGoalTracker() {
     if (goalTracker) {
       goalTracker.dispose();
     }
     if (goals && goals.length) {
       goalTracker = GoalTracker(goals, sendGoalEvent);
-    } 
+    }
   }
 
   if (goals && goals.length > 0) {
     if (!!(window.history && history.pushState)) {
-      window.addEventListener('popstate', refreshGoalTracker);  
+      window.addEventListener('popstate', refreshGoalTracker);
     } else {
       window.addEventListener('hashchange', refreshGoalTracker);
     }
@@ -304,6 +323,6 @@ module.exports = {
   initialize: initialize
 };
 
-if(typeof VERSION !== 'undefined') {
+if (typeof VERSION !== 'undefined') {
   module.exports.version = VERSION;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const webpack = require('webpack');
+const RewirePlugin = require("rewire-webpack");
 const package = require('./package.json');
 
 module.exports = {
@@ -9,6 +10,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       VERSION: JSON.stringify(package.version)
-    })
+    }),
+    new RewirePlugin()
   ]
 };


### PR DESCRIPTION
Hi guys, we are almost going live with launch darkly and so far we are loving it! One thing I found while dealing with keys is that the dash-separated keys (also called kebab-cased) don't play nice with json and javascript in general. For example, I can't do :

`
const flag = featureFlags.show-red-button; // does not work
`

Instead, I have to do:

`
const flag = featureFlags['show-red-button']; // works, but not very developer friendly
`

So I spent some time adding code to the js client to support camelCased keys so front end devs like me can access the feature flags using camel cased keys:

`
const flag = featureFlags.showRedButton; // this works now
`

The way I do it is by lowercasing and stripping dashes off keys in the sdk prior to accessing it in the flags object. I have added comprehensive unit tests to ensure existing kebab-cased keys still work and also ensuring the new camelCasedKeys work. 

At the moment we are manually doing this in our application, adding quite a bit of boilerplate code in process to camel case keys manually when accessing and then storing the flags. It will be good to have this in the sdk so we can remove all that boilerplate code and focus on the good stuff!

Please review and let me know if this is ok.

Thanks,
Yus
