### PR TITLE
do not update settings if none were received (likely because a reques…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -133,9 +133,14 @@ function connectStream() {
 }
 
 function updateSettings(settings) {
-  var changes = utils.modifications(flags, settings);
-  var keys = Object.keys(changes);
+  var changes;
+  var keys;
   
+  if (!settings) { return; }
+
+  utils.modifications(flags, settings);
+  Object.keys(changes);
+
   flags = settings;
 
   if (useLocalStorage) {

--- a/src/index.js
+++ b/src/index.js
@@ -138,8 +138,8 @@ function updateSettings(settings) {
   
   if (!settings) { return; }
 
-  utils.modifications(flags, settings);
-  Object.keys(changes);
+  changes = utils.modifications(flags, settings);
+  keys = Object.keys(changes);
 
   flags = settings;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,7 +18,7 @@ function clone(obj) {
 
 function modifications(oldObj, newObj) {
   var mods = {};
-  
+  if (!oldObj || !newObj) { return {}; }
   for (var prop in oldObj) {
     if (oldObj.hasOwnProperty(prop)) {
       if (newObj[prop] !== oldObj[prop]) {


### PR DESCRIPTION
…t error occured)

We should always check `settings` here.

Fixes #27 .