### PR TITLE
Preserve cached settings when connection to LD is broken

### DIFF
--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -4,17 +4,33 @@ var semverCompare = require('semver-compare');
 describe('LDClient', function() {
   var xhr;
   var requests = [];
+  var sandbox;
+  var store = {};
+
+  var lsKey = 'ld:UNKNOWN_ENVIRONMENT_ID:user';
+  
   
   beforeEach(function() {
     xhr = sinon.useFakeXMLHttpRequest();
     xhr.onCreate = function(req) {
       requests.push(req);
     };
+
+    sandbox = sinon.sandbox.create();    
+    sandbox.stub(window.localStorage.__proto__, 'setItem', function(k, v) {
+      store[k] = v;
+    });
+
+    sandbox.stub(window.localStorage.__proto__, 'getItem', function(k) {
+      return store[k];
+    });
   });
   
   afterEach(function() {
     requests = [];
     xhr.restore();
+
+    sandbox.restore();
   });
   
   it('should exist', function() {
@@ -57,6 +73,63 @@ describe('LDClient', function() {
 
       // Assert
       expect(result).to.equal(1);
+    });
+
+    it('should clear cached settings if they are invalid JSON', function(done) {
+      var user = {key: 'user'};
+      var client;
+
+      window.localStorage.setItem(lsKey, 'foo{bar}');
+
+      client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: 'localstorage'
+      });
+
+      client.on('ready', function() {
+        expect(window.localStorage.getItem(lsKey)).to.be.null;
+        done();
+      });
+    });
+    
+    it('should not clear cached settings if they are valid JSON', function(done) {
+      var json = '{"enable-thing": true}';
+      var user = {key: 'user'};
+      var client;
+
+      window.localStorage.setItem(lsKey, json);
+
+      client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: 'localstorage'
+      });
+
+      client.on('ready', function() {
+        expect(window.localStorage.getItem(lsKey)).to.equal(json);
+        done();
+      });
+    });
+
+    it('should not update cached settings if there was an error fetching flags', function(done) {
+      var user = {key: 'user'};
+      var json = '{"enable-foo": true}';
+
+      window.localStorage.setItem(lsKey, json);
+
+      var server = sinon.fakeServer.create();
+      server.respondWith(function(req) {
+        req.respond(503);
+      });
+
+      client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: 'localstorage'
+      });
+
+      client.on('ready', function() {
+        server.respond();
+        setTimeout(function() {
+          expect(window.localStorage.getItem(lsKey)).to.equal(json);
+          done();
+        }, 1);
+      });
     });
   });
   

--- a/src/index.js
+++ b/src/index.js
@@ -240,8 +240,8 @@ function initialize(env, user, options) {
 
     if (flags === null) {
       requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
-        flags = settings;
-        localStorage.setItem(localStorageKey, JSON.stringify(flags));
+        flags = settings; 
+        settings && localStorage.setItem(localStorageKey, JSON.stringify(flags));          
         emitter.emit(readyEvent);
       });
     } else {
@@ -250,7 +250,7 @@ function initialize(env, user, options) {
       // the in-memory flags unless you subscribe for changes
       setTimeout(function() { emitter.emit(readyEvent); }, 0);
       requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
-        localStorage.setItem(localStorageKey, JSON.stringify(settings));
+        settings && localStorage.setItem(localStorageKey, JSON.stringify(settings));
       });
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -241,7 +241,7 @@ function initialize(env, user, options) {
     if (flags === null) {
       requestor.fetchFlagSettings(ident.getUser(), hash, function(err, settings) {
         flags = settings; 
-        settings && localStorage.setItem(localStorageKey, JSON.stringify(flags));          
+        settings && localStorage.setItem(localStorageKey, JSON.stringify(flags));
         emitter.emit(readyEvent);
       });
     } else {


### PR DESCRIPTION
This change ensures that we do not overwrite settings cached in `localStorage` with `null`. This can happen when the connection to LD is broken.

I also added a few tests around `localStorage`, including one for the case where we do want to clear `localStorage` because it contains invalid JSON.