### PR TITLE
Refactored `waitUntilReady()` to always resolve even after `ready` event was already emitted

### DIFF
--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -71,6 +71,22 @@ describe('LDClient', function() {
       });
     });
 
+    it('should resolve waitUntilReady promise when ready after ready event was already emitted', function(done) {
+      var user = {key: 'user'};
+      var handleReady = sinon.spy();
+      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {}
+      });
+      setTimeout(function () {
+        client.waitUntilReady().then(handleReady);
+        setTimeout(function () {
+          expect(handleReady.called).to.be.true;
+          done();
+        }, 0);
+      }, 1000);
+    });
+
+
     it('should log an error when initialize is called without an environment key', function(done) {
       var user = {key: 'user'};
       var errorSpy = sinon.spy(console, 'error');

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -71,15 +71,21 @@ describe('LDClient', function() {
       });
     });
 
-    it('should resolve waitUntilReady promise when ready after ready event was already emitted', function(done) {
-      var user = {key: 'user'};
+    it('should resolve waitUntilReady promise after ready event was already emitted', function(done) {
+      var user = { key: 'user' };
+      var handleInitialReady = sinon.spy();
       var handleReady = sinon.spy();
       var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
         bootstrap: {}
       });
+
+      client.on('ready', handleInitialReady);
+
       setTimeout(function () {
         client.waitUntilReady().then(handleReady);
+
         setTimeout(function () {
+          expect(handleInitialReady.called).to.be.true;
           expect(handleReady.called).to.be.true;
           done();
         }, 0);

--- a/src/index.js
+++ b/src/index.js
@@ -388,12 +388,12 @@ function initialize(env, user, options) {
 
   window.addEventListener('message', handleMessage);
 
+  client.on('ready', function () {
+    ldPromise = Promise.resolve(client);
+  });
+
   return client;
 }
-
-client.on('ready', function () {
-  ldPromise = Promise.resolve(client);
-});
 
 module.exports = {
   initialize: initialize

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ var flushInterval = 2000;
 
 var seenRequests = {};
 
+var ldPromise = Promise.reject('LaunchDarkly is not ready');
+
 function sendIdentifyEvent(user) {
   enqueueEvent({
     kind: 'identify',
@@ -82,9 +84,7 @@ function sendGoalEvent(kind, goal) {
 }
 
 function waitUntilReady() {
-  return new Promise(function(resolve) {
-    client.on('ready', resolve);
-  });
+  return ldPromise;
 }
 
 function identify(user, hash, onDone) {
@@ -390,6 +390,10 @@ function initialize(env, user, options) {
 
   return client;
 }
+
+client.on('ready', function () {
+  ldPromise = Promise.resolve(client);
+});
 
 module.exports = {
   initialize: initialize

--- a/src/index.js
+++ b/src/index.js
@@ -388,8 +388,9 @@ function initialize(env, user, options) {
 
   window.addEventListener('message', handleMessage);
 
-  client.on('ready', function () {
+  var onReady = client.on('ready', function () {
     ldPromise = Promise.resolve(client);
+    client.off(onReady);
   });
 
   return client;

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ var flushInterval = 2000;
 
 var seenRequests = {};
 
-var ldPromise = Promise.reject('LaunchDarkly is not ready');
+var ldPromise = Promise.reject(messages.clientNotReady());
 
 function sendIdentifyEvent(user) {
   enqueueEvent({

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,4 +1,7 @@
 module.exports ={
+  clientNotReady: function() {
+    return 'LaunchDarkly client is not ready';
+  },
   invalidKey: function() {
     return 'Event key must be a string';
   },


### PR DESCRIPTION
The current `waitUntilReady()` method will never resolve if the 'ready' event fires after the client's code is run. This implementation will maintain the state of the promise and will always resolve even after the 'ready' event was emitted.