### PR TITLE
prepare 1.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. This 
 project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.5.0] - 2018-03-05
+### Added
+- The `options` object now supports a `samplingInterval` property. If greater than zero, this causes a fraction of analytics events to be sent to LaunchDarkly: one per that number of events (pseudo-randomly). For instance, setting it to 5 would cause 20% of events to be sent on average.
+
 ## [1.4.0] - 2018-02-07
 ### Added
 - The SDK now supports multiple environments. Calling `initialize` returns a new client each time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.3.1",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/EventSerializer.js
+++ b/src/EventSerializer.js
@@ -28,7 +28,6 @@ function EventSerializer(config) {
   }
 
   function filter_user(user) {
-    var allPrivateAttrs = {};
     var userPrivateAttrs = user.privateAttributeNames || [];
     
     var isPrivateAttr = function(name) {

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -65,7 +65,7 @@ describe('LDClient', function() {
         });
 
         client.waitUntilReady().then(handleReady);
-  
+
         client.on('ready', function() {
           setTimeout(function() {
             expect(handleReady.called).to.be.true;
@@ -73,7 +73,7 @@ describe('LDClient', function() {
           }, 0);
         });
       });
-  
+
       it('should resolve waitUntilReady promise after ready event was already emitted', function(done) {
         var user = { key: 'user' };
         var handleInitialReady = sinon.spy();
@@ -81,18 +81,33 @@ describe('LDClient', function() {
         var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
           bootstrap: {}
         });
-  
+
         client.on('ready', handleInitialReady);
-  
+
         setTimeout(function () {
           client.waitUntilReady().then(handleReady);
-  
+
           setTimeout(function () {
             expect(handleInitialReady.called).to.be.true;
             expect(handleReady.called).to.be.true;
             done();
           }, 0);
         }, 0);
+      });
+    });
+
+    it('should emit an error when an invalid samplingInterval is specified', function(done) {
+      var user = { key: 'user' };
+      var handleInitialReady = sinon.spy();
+      var handleReady = sinon.spy();
+      var client = LDClient.initialize('UNKNOWN_ENVIRONMENT_ID', user, {
+        bootstrap: {},
+        samplingInterval: "totally not a number"
+      });
+
+      client.on('error', function(err) {
+        expect(err.message).to.be.equal('Invalid sampling interval configured. Sampling interval must be an integer >= 0.');
+        done();
       });
     });
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,4 +16,5 @@ exports.LDUnexpectedResponseError = createCustomError('LaunchDarklyUnexpectedRes
 exports.LDInvalidEnvironmentIdError = createCustomError('LaunchDarklyInvalidEnvironmentIdError');
 exports.LDInvalidUserError = createCustomError('LaunchDarklyInvalidUserError');
 exports.LDInvalidEventKeyError = createCustomError('LaunchDarklyInvalidEventKeyError');
+exports.LDInvalidArgumentError = createCustomError('LaunchDarklyInvalidArgumentError');
 exports.LDFlagFetchError = createCustomError('LaunchDarklyFlagFetchError');

--- a/src/messages.js
+++ b/src/messages.js
@@ -14,7 +14,7 @@ module.exports = {
     return 'Custom event "' + key + '" does not exist';
   },
   environmentNotFound: function() {
-    return 'environment not found.' + docLink;
+    return 'Environment not found.' + docLink;
   },
   environmentNotSpecified: function() {
     return 'No environment specified.' + docLink;


### PR DESCRIPTION
## [1.5.0] - 2018-03-05
### Added
- The `options` object now supports a `samplingInterval` property. If greater than zero, this causes a fraction of analytics events to be sent to LaunchDarkly: one per that number of events (pseudo-randomly). For instance, setting it to 5 would cause 20% of events to be sent on average.
