### PR TITLE
prepare 1.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [1.6.0] - 2018-03-28
 ### Changed
-- To reduce network usage, if you have subscribed to change events, the client now connects to a new streaming endpoint that delivers individual feature flag changes as they occur. Previously, it made a new connection and re-requested all flags whenever a change was detected.
+- Added support for a future update to LaunchDarkly that will deliver individual feature flag changes over the streaming connection as they occur, rather than requiring the client to re-request all flags for each change.
 
 ## [1.5.2] - 2018-03-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. This 
 project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.6.0] - 2018-03-28
+### Changed
+- To reduce network usage, if you have subscribed to change events, the client now connects to a new streaming endpoint that delivers individual feature flag changes as they occur. Previously, it made a new connection and re-requested all flags whenever a change was detected.
+
 ## [1.5.2] - 2018-03-28
 ### Added
 - The new flush method on the client object tells the client to deliver any stored analytics events as soon as possible, rather than waiting for the regularly scheduled event-flushing interval.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/Requestor.js
+++ b/src/Requestor.js
@@ -55,8 +55,12 @@ function Requestor(baseUrl, environment, useReport) {
     }
 
     var wrappedCallback = (function(currentCallback) {
-      return function() {
-        currentCallback.apply(null, arguments);
+      return function(error, result) {
+        // if we got flags, convert them to the more verbose format used by the eval stream
+        if (result) {
+          result = utils.transformValuesToVersionedValues(result);
+        }
+        currentCallback(error, result);
         flagSettingsRequest = null;
         lastFlagSettingsCallback = null;
       };

--- a/src/Stream.js
+++ b/src/Stream.js
@@ -1,12 +1,29 @@
-function Stream(url, environment) {
+var utils = require('./utils');
+
+function Stream(baseUrl, environment, hash, useReport) {
   var stream = {};
-  var url = url + '/ping/' + environment;
+  var evalUrlPrefix = baseUrl + '/eval/' + environment + '/';
   var es = null;
 
-  stream.connect = function(onPing) {
+  stream.connect = function(user, handlers) {
     if (typeof EventSource !== 'undefined') {
+      var url;
+      if (useReport) {
+        // we don't yet have an EventSource implementation that supports REPORT, so
+        // fall back to the old ping-based stream
+        url = baseUrl + '/ping/' + environment;
+      } else {
+        url = evalUrlPrefix + utils.base64URLEncode(JSON.stringify(user));
+        if (hash !== null && hash !== undefined) {
+          url = url + '?h=' + hash;
+        }
+      }
       es = new window.EventSource(url);
-      es.addEventListener('ping', onPing);
+      for (var key in handlers) {
+        if (handlers.hasOwnProperty(key)) {
+          es.addEventListener(key, handlers[key]);
+        }
+      }
     }
   }
 

--- a/src/__tests__/Stream-test.js
+++ b/src/__tests__/Stream-test.js
@@ -1,11 +1,27 @@
 var Stream = require('../Stream');
-
+var mockEventSource = require('./mockEventSource');
 var noop = function() {};
 
 describe('Stream', function() {
+  var baseUrl = 'https://example.com';
+  var envName = 'testenv';
+  var user = { key: 'me' };
+  var encodedUser = 'eyJrZXkiOiJtZSJ9';
+  var hash = '012345789abcde';
+
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    sandbox.stub(window, 'EventSource', mockEventSource.new);
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
   it('should not throw on EventSource when it does not exist', function() {
     window.EventSource = undefined;
-    var stream = new Stream('https://example.com', 'test');
+    
+    var stream = new Stream(baseUrl, envName);
 
     var connect = function() {
       stream.connect(noop);
@@ -13,13 +29,48 @@ describe('Stream', function() {
 
     expect(connect).to.not.throw(TypeError);
   });
+
   it('should not throw when calling disconnect without first calling connect', function() {
-    var stream = new Stream('https://example.com', 'test');
+    var stream = new Stream(baseUrl, envName);
 
     var disconnect = function() {
       stream.disconnect(noop);
     }
 
     expect(disconnect).to.not.throw(TypeError);
-  })
+  });
+
+  it('connects to EventSource with eval stream URL by default', function() {
+    var stream = new Stream(baseUrl, envName, null, false);
+    stream.connect(user, {});
+
+    expect(mockEventSource.connectedUrl).to.equal(baseUrl + '/eval/' + envName + '/' + encodedUser);
+  });
+
+  it('adds secure mode hash to URL if provided', function() {
+    var stream = new Stream(baseUrl, envName, hash, false);
+    stream.connect(user, {});
+
+    expect(mockEventSource.connectedUrl).to.equal(baseUrl + '/eval/' + envName + '/' + encodedUser + '?h=' + hash);
+  });
+
+  it('falls back to ping stream URL if useReport is true', function() {
+    var stream = new Stream(baseUrl, envName, hash, true);
+    stream.connect(user, {});
+
+    expect(mockEventSource.connectedUrl).to.equal(baseUrl + '/ping/' + envName);
+  });
+
+  it('sets event listeners', function() {
+    var stream = new Stream(baseUrl, envName, hash, false);
+    var fn1 = function() { return 0; };
+    var fn2 = function() { return 1; };
+    stream.connect(user, {
+      birthday: fn1,
+      anniversary: fn2
+    });
+
+    expect(mockEventSource.listeners['birthday']).to.equal(fn1);
+    expect(mockEventSource.listeners['anniversary']).to.equal(fn2);
+  });
 });

--- a/src/__tests__/mockEventSource.js
+++ b/src/__tests__/mockEventSource.js
@@ -1,0 +1,22 @@
+
+var mockEventSource = function() {
+  var mes = {
+    connectedUrl: null,
+    listeners: {}
+  };
+  mes.new = function(url) {
+    mes.connectedUrl = url;
+    var es = {};
+    es.addEventListener = function(key, handler) {
+      mes.listeners[key] = handler;
+    };
+    es.close = function() {
+      es.readyState = EventSource.CLOSED;
+    }
+    es.readyState = EventSource.OPEN;
+    return es;
+  };
+  return mes;
+}();
+
+module.exports = mockEventSource;

--- a/src/utils.js
+++ b/src/utils.js
@@ -16,21 +16,7 @@ function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
-function modifications(oldObj, newObj) {
-  var mods = {};
-  if (!oldObj || !newObj) { return {}; }
-  for (var prop in oldObj) {
-    if (oldObj.hasOwnProperty(prop)) {
-      if (newObj[prop] !== oldObj[prop]) {
-        mods[prop] = {previous: oldObj[prop], current: newObj[prop]};
-      }
-    }
-  }
-
-  return mods;
-}
-
-// Events emmited in LDClient's initialize method will happen before the consumer
+// Events emitted in LDClient's initialize method will happen before the consumer
 // can register a listener, so defer them to next tick.
 function onNextTick(cb) {
   setTimeout(cb, 0);
@@ -92,6 +78,34 @@ function wrapPromiseCallback(promise, callback) {
 }
 
 /**
+ * Takes a map of flag keys to values, and returns the more verbose structure used by the
+ * client stream.
+ */
+function transformValuesToVersionedValues(flags) {
+  var ret = {};
+  for (var key in flags) {
+    if (flags.hasOwnProperty(key)) {
+      ret[key] = { value: flags[key], version: 0 };
+    }
+  }
+  return ret;
+}
+
+/**
+ * Takes a map obtained from the client stream and converts it to the briefer format used in
+ * bootstrap data or local storagel
+ */
+function transformValuesToUnversionedValues(flags) {
+  var ret = {};
+  for (var key in flags) {
+    if (flags.hasOwnProperty(key)) {
+      ret[key] = flags[key].value;
+    }
+  }
+  return ret;
+}
+
+/**
  * Returns an array of event groups each of which can be safely URL-encoded
  * without hitting the safe maximum URL length of certain browsers.
  * 
@@ -133,9 +147,10 @@ module.exports = {
   btoa: btoa,
   base64URLEncode: base64URLEncode,
   clone: clone,
-  modifications: modifications,
   merge: merge,
   onNextTick: onNextTick,
+  transformValuesToVersionedValues: transformValuesToVersionedValues,
+  transformValuesToUnversionedValues: transformValuesToUnversionedValues,
   wrapPromiseCallback: wrapPromiseCallback,
   chunkUserEventsForUrl: chunkUserEventsForUrl
 };


### PR DESCRIPTION
## [1.6.0] - 2018-03-28
### Changed
- Added support for a future update to LaunchDarkly that will deliver individual feature flag changes over the streaming connection as they occur, rather than requiring the client to re-request all flags for each change.