### PR TITLE
prepare 1.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org).
 - The client no longer creates an empty `XMLHttpRequest` at startup time (which could interfere with unit tests).
 
 ## [1.7.1] - 2018-05-07
-''This release was broken and should not be used.''
+_This release was broken and should not be used._
 
 ## [1.7.0] - 2018-04-27
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
-## [1.7.1] - 2018-05-07
+## [1.7.2] - 2018-05-07
 ### Fixed
 - The client no longer creates an empty `XMLHttpRequest` at startup time (which could interfere with unit tests).
-- The client now sends the SDK version to LaunchDarkly; previously it only sent the browser version. This will allow for better usage metrics in a future version of the LaunchDarkly UI.
+
+## [1.7.1] - 2018-05-07
+''This release was broken and should not be used.''
 
 ## [1.7.0] - 2018-04-27
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/EventProcessor.js
+++ b/src/EventProcessor.js
@@ -13,7 +13,6 @@ function sendEvents(eventsUrl, events, sync) {
     if (hasCors) {
       /* supports cross-domain requests */
       xhr.open('GET', src, !sync);
-      utils.addLDHeaders(xhr);
 
       if (!sync) {
         xhr.addEventListener('load', onDone);

--- a/src/__tests__/EventProcessor-test.js
+++ b/src/__tests__/EventProcessor-test.js
@@ -66,15 +66,4 @@ describe('EventProcessor', () => {
     expect(requests.length).toEqual(1);
     expect(requests[0].async).toEqual(false);
   });
-
-  it('should send custom user-agent header', () => {
-    const processor = EventProcessor('/fake-url', serializer);
-    const user = { key: 'foo' };
-    const event = { kind: 'identify', key: user.key };
-    processor.enqueue(event);
-    processor.flush(user, true);
-
-    expect(requests.length).toEqual(1);
-    expect(requests[0].requestHeaders['X-LaunchDarkly-User-Agent']).toEqual(utils.getLDUserAgentString());
-  });
 });

--- a/src/__tests__/EventProcessor-test.js
+++ b/src/__tests__/EventProcessor-test.js
@@ -2,7 +2,6 @@ import sinon from 'sinon';
 
 import EventSerializer from '../EventSerializer';
 import EventProcessor from '../EventProcessor';
-import * as utils from '../utils';
 
 describe('EventProcessor', () => {
   let sandbox;


### PR DESCRIPTION
## [1.7.2] - 2018-05-07
### Fixed
- The client no longer creates an empty `XMLHttpRequest` at startup time (which could interfere with unit tests).

## [1.7.1] - 2018-05-07
_This release was broken and should not be used._