### PR TITLE
prepare 1.7.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.7.4] - 2018-05-23
+### Fixed
+- Fixed a bug that caused events _not_ to be sent if `options.sendEvents` was explicitly set to `true`.
+- HTTP requests will no longer fail if there is a `charset` specified in the response's `Content-Type` header. ([#87](https://github.com/launchdarkly/js-client/issues/87))
+
 ## [1.7.3] - 2018-05-08
 ### Fixed
 - The client no longer creates an empty `XMLHttpRequest` at startup time (which could interfere with unit tests).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/Requestor.js
+++ b/src/Requestor.js
@@ -8,7 +8,11 @@ function fetchJSON(endpoint, body, callback) {
   const xhr = new XMLHttpRequest();
 
   xhr.addEventListener('load', () => {
-    if (xhr.status === 200 && xhr.getResponseHeader('Content-type') === json) {
+    if (
+      xhr.status === 200 &&
+      xhr.getResponseHeader('Content-type') &&
+      xhr.getResponseHeader('Content-Type').startsWith(json)
+    ) {
       callback(null, JSON.parse(xhr.responseText));
     } else {
       callback(xhr.statusText);

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ function initialize(env, user, options = {}) {
   const eventsUrl = options.eventsUrl || 'https://events.launchdarkly.com';
   const streamUrl = options.streamUrl || 'https://clientstream.launchdarkly.com';
   const hash = options.hash;
-  const sendEvents = typeof options.sendEvents === 'undefined' ? true : config.sendEvents;
+  const sendEvents = typeof options.sendEvents === 'undefined' ? true : options.sendEvents;
   const environment = env;
   const emitter = EventEmitter();
   const stream = Stream(streamUrl, environment, hash, options.useReport);


### PR DESCRIPTION
## [1.7.4] - 2018-05-23
### Fixed
- Fixed a bug that caused events _not_ to be sent if `options.sendEvents` was explicitly set to `true`.
- HTTP requests will no longer fail if there is a `charset` specified in the response's `Content-Type` header. ([#87](https://github.com/launchdarkly/js-client/issues/87))
