### PR TITLE
Updated typescript declarations for private fields related configuration options

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,6 +114,22 @@ declare module 'ldclient-js' {
      * Do not use unless advised by LaunchDarkly.
      */
     useReport?: boolean;
+
+    /**
+     * Whether all user attributes (except the user key) should be marked as
+     * private, and not sent to LaunchDarkly.
+     *
+     * Defaults to false.
+     */
+    allAttributesPrivate?: boolean;
+
+    /**
+     * The names of user attributes that should be marked as private, and not sent
+     * to LaunchDarkly.
+     *
+     * Must be a list of strings. Defaults to empty list.
+     */
+    privateAttributeNames?: Array<string>;
   }
 
   /**


### PR DESCRIPTION
This allows TypeScript users to use the allAttributesPrivate and privateAttributeNames options in js-client (configuration options used in UserFilter class).

Description is taken from https://docs.launchdarkly.com/docs/node-sdk-reference and only very slightly updated.