### PR TITLE
prepare 2.1.1 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,7 @@ jobs:
       - run: npm install
       - run: mkdir -p reports/junit
       - run: npm run lint:all
+      - run: npm run build
       - run:
           command: npm run test:junit
           environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.1.1] - 2018-06-05
+### Fixed:
+- Removed two function calls that are not supported in Internet Explorer: `string.startsWith()` and `Object.assign()`.
+
 ## [2.1.0] - 2018-05-31
 ### Added:
 - The client now sends the current SDK version to LaunchDarkly in an HTTP header. This information will be visible in a future version of the LaunchDarkly UI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "1.6.2",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/EventProcessor.js
+++ b/src/EventProcessor.js
@@ -54,7 +54,7 @@ export default function EventProcessor(eventsUrl, environmentId, options = {}, e
 
   // Transform an event from its internal format to the format we use when sending a payload.
   function makeOutputEvent(e) {
-    const ret = Object.assign({}, e);
+    const ret = { ...e };
     if (inlineUsers || e.kind === 'identify') {
       // identify events always have an inline user
       ret.user = userFilter.filterUser(e.user);
@@ -94,7 +94,7 @@ export default function EventProcessor(eventsUrl, environmentId, options = {}, e
       queue.push(makeOutputEvent(event));
     }
     if (addDebugEvent) {
-      const debugEvent = Object.assign({}, event, { kind: 'debug' });
+      const debugEvent = { ...event, kind: 'debug' };
       delete debugEvent['trackEvents'];
       delete debugEvent['debugEventsUntilDate'];
       delete debugEvent['variation'];

--- a/src/EventProcessor.js
+++ b/src/EventProcessor.js
@@ -54,7 +54,7 @@ export default function EventProcessor(eventsUrl, environmentId, options = {}, e
 
   // Transform an event from its internal format to the format we use when sending a payload.
   function makeOutputEvent(e) {
-    const ret = { ...e };
+    const ret = utils.extend({}, e);
     if (inlineUsers || e.kind === 'identify') {
       // identify events always have an inline user
       ret.user = userFilter.filterUser(e.user);
@@ -94,7 +94,7 @@ export default function EventProcessor(eventsUrl, environmentId, options = {}, e
       queue.push(makeOutputEvent(event));
     }
     if (addDebugEvent) {
-      const debugEvent = { ...event, kind: 'debug' };
+      const debugEvent = utils.extend({}, event, { kind: 'debug' });
       delete debugEvent['trackEvents'];
       delete debugEvent['debugEventsUntilDate'];
       delete debugEvent['variation'];

--- a/src/Requestor.js
+++ b/src/Requestor.js
@@ -11,7 +11,7 @@ function fetchJSON(endpoint, body, callback) {
     if (
       xhr.status === 200 &&
       xhr.getResponseHeader('Content-type') &&
-      xhr.getResponseHeader('Content-Type').startsWith(json)
+      xhr.getResponseHeader('Content-Type').lastIndexOf(json) === 0
     ) {
       callback(null, JSON.parse(xhr.responseText));
     } else {

--- a/src/Store.js
+++ b/src/Store.js
@@ -39,7 +39,7 @@ export default function Store(environment, hash, ident) {
 
   store.saveFlags = function(flags) {
     const key = getFlagsKey();
-    const data = { ...flags, $schema: 1 };
+    const data = utils.extend({}, flags, { $schema: 1 });
     try {
       localStorage.setItem(key, JSON.stringify(data));
     } catch (ex) {

--- a/src/Store.js
+++ b/src/Store.js
@@ -39,7 +39,7 @@ export default function Store(environment, hash, ident) {
 
   store.saveFlags = function(flags) {
     const key = getFlagsKey();
-    const data = Object.assign({}, flags, { $schema: 1 });
+    const data = { ...flags, $schema: 1 };
     try {
       localStorage.setItem(key, JSON.stringify(data));
     } catch (ex) {

--- a/src/UserFilter.js
+++ b/src/UserFilter.js
@@ -65,11 +65,11 @@ export default function UserFilter(config) {
     };
     const result = filterAttrs(user, key => allowedTopLevelAttrs[key]);
     const filteredProps = result[0];
-    const removedAttrs = result[1];
+    let removedAttrs = result[1];
     if (user.custom) {
       const customResult = filterAttrs(user.custom, () => true);
       filteredProps.custom = customResult[0];
-      Object.assign(removedAttrs, customResult[1]);
+      removedAttrs = { ...removedAttrs, ...customResult[1] };
     }
     const removedAttrNames = Object.keys(removedAttrs);
     if (removedAttrNames.length) {

--- a/src/UserFilter.js
+++ b/src/UserFilter.js
@@ -1,4 +1,5 @@
 import * as messages from './messages';
+import * as utils from './utils';
 
 /**
  * The UserFilter object transforms user objects into objects suitable to be sent as JSON to
@@ -69,7 +70,7 @@ export default function UserFilter(config) {
     if (user.custom) {
       const customResult = filterAttrs(user.custom, () => true);
       filteredProps.custom = customResult[0];
-      removedAttrs = { ...removedAttrs, ...customResult[1] };
+      removedAttrs = utils.extend({}, removedAttrs, customResult[1]);
     }
     const removedAttrNames = Object.keys(removedAttrs);
     if (removedAttrNames.length) {

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ function initialize(env, user, options = {}) {
         const oldFlag = flags[data.key];
         if (!oldFlag || !oldFlag.version || !data.version || oldFlag.version < data.version) {
           const mods = {};
-          const newFlag = Object.assign({}, data);
+          const newFlag = { ...data };
           delete newFlag['key'];
           flags[data.key] = newFlag;
           if (oldFlag) {

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ function initialize(env, user, options = {}) {
         const oldFlag = flags[data.key];
         if (!oldFlag || !oldFlag.version || !data.version || oldFlag.version < data.version) {
           const mods = {};
-          const newFlag = { ...data };
+          const newFlag = utils.extend({}, data);
           delete newFlag['key'];
           flags[data.key] = newFlag;
           if (oldFlag) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -123,3 +123,7 @@ export function getLDUserAgentString() {
 export function addLDHeaders(xhr) {
   xhr.setRequestHeader('X-LaunchDarkly-User-Agent', getLDUserAgentString());
 }
+
+export function extend(...objects) {
+  return objects.reduce((acc, obj) => ({ ...acc, ...obj }), {});
+}


### PR DESCRIPTION
## [2.1.1] - 2018-06-05
### Fixed:
- Removed two function calls that are not supported in Internet Explorer: `string.startsWith()` and `Object.assign()`.
