### PR TITLE
Fix localStorage case

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ var client = LDClient.initialize(
   'YOUR_CLIENT_SIDE_ID',
   user,
   (options = {
-    bootstrap: 'localStorage',
+    bootstrap: 'localstorage',
   })
 );
 ```


### PR DESCRIPTION
There is a typo in the example to bootstrap LaunchDarkly client, which prevents the application to work properly if you copy and paste the code directly.