### PR TITLE
Prepare 2.1.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.1.2] - 2018-06-08
+### Fixed:
+- Fix the TypeScript definitions to properly support the ES default export.
+
 ## [2.1.1] - 2018-06-05
 ### Fixed:
 - Removed two function calls that are not supported in Internet Explorer: `string.startsWith()` and `Object.assign()`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldclient-js v2.1.1
+// Type definitions for ldclient-js v2.1.2
 // Project: https://github.com/launchdarkly/js-client
 // Definitions by: Isaac Sukin <https://isaacsukin.com>
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldclient-js v1.1.2
+// Type definitions for ldclient-js v2.1.1
 // Project: https://github.com/launchdarkly/js-client
 // Definitions by: Isaac Sukin <https://isaacsukin.com>
 
@@ -8,10 +8,12 @@
  * Documentation: http://docs.launchdarkly.com/docs/js-sdk-reference
  */
 declare module 'ldclient-js' {
-  /**
-   * The LaunchDarkly static global.
-   */
-  export function initialize(envKey: string, user: LDUser, options?: LDOptions): LDClient;
+  const LaunchDarkly : {
+    initialize: (envKey: string, user: LDUser, options?: LDOptions) => LDClient
+    version: string
+  };
+
+  export default LaunchDarkly;
 
   /**
    * The names of events to which users of the client can subscribe.


### PR DESCRIPTION
## [2.1.2] - 2018-06-08
### Fixed:
- Fix the TypeScript definitions to properly support the ES default export.