### PR TITLE
Ensure flags isn't set to null if bootstrapping

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -405,6 +405,7 @@ function initialize(env, user, options = {}) {
     flags = store.loadFlags();
 
     if (flags === null) {
+      flags = {}
       requestor.fetchFlagSettings(ident.getUser(), hash, (err, settings) => {
         if (err) {
           emitter.maybeReportError(new errors.LDFlagFetchError(messages.errorFetchingFlags(err)));


### PR DESCRIPTION
When upgrading from 1.7.0 to 2.1.2 we ran into an unexpected breaking change where although we bootstrap with localStorage, the flags would now be set to `null` leading to any calls to `variation` to throw until the client is fully ready. The behavior in the older version with the empty object allowed calls to `variation` to succeed before ready, but would simply use the default fallback value.

This change restores that old behavior.