### PR TITLE
prepare 2.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.2.0] - 2018-06-22
+### Added:
+- New event `goalsReady` (and new method `waitUntilGoalsReady`, which returns a Promise based on that event) indicates when the client has loaded goals-- i.e. when it is possible for pageview events and click events to be triggered.
+
+### Fixed:
+- Fixed a bug where calling `variation` would throw an error if the client was bootstrapped from local storage and there were no flags in local storage yet, and the initial HTTP request for flags from LaunchDarkly had not yet completed. (thanks, [mpcowan](https://github.com/launchdarkly/js-client/pull/97)!)
+
 ## [2.1.2] - 2018-06-08
 ### Fixed:
 - Fix the TypeScript definitions to properly support the ES default export.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for ldclient-js v1.1.2
+// Type definitions for ldclient-js v2.1.1
 // Project: https://github.com/launchdarkly/js-client
 // Definitions by: Isaac Sukin <https://isaacsukin.com>
 
@@ -8,10 +8,12 @@
  * Documentation: http://docs.launchdarkly.com/docs/js-sdk-reference
  */
 declare module 'ldclient-js' {
-  /**
-   * The LaunchDarkly static global.
-   */
-  export function initialize(envKey: string, user: LDUser, options?: LDOptions): LDClient;
+  const LaunchDarkly : {
+    initialize: (envKey: string, user: LDUser, options?: LDOptions) => LDClient
+    version: string
+  };
+
+  export default LaunchDarkly;
 
   /**
    * The names of events to which users of the client can subscribe.


### PR DESCRIPTION
## [2.2.0] - 2018-06-22
### Added:
- New event `goalsReady` (and new method `waitUntilGoalsReady`, which returns a Promise based on that event) indicates when the client has loaded goals-- i.e. when it is possible for pageview events and click events to be triggered.

### Fixed:
- Fixed a bug where calling `variation` would throw an error if the client was bootstrapped from local storage and there were no flags in local storage yet, and the initial HTTP request for flags from LaunchDarkly had not yet completed. (thanks, [mpcowan](https://github.com/launchdarkly/js-client/pull/97)!)
