### PR TITLE
prepare 2.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file. 
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.3.0] - 2018-06-26
+### Changed:
+The client will now stop trying to send analytics events if it receives almost any HTTP 4xx error from LaunchDarkly; such errors indicate either a configuration problem (invalid SDK key) or a bug, which is not likely to resolve without a restart or an upgrade. This does not apply if the error is 400, 408, or 429.
+
 ## [2.2.0] - 2018-06-22
 ### Added:
 - New event `goalsReady` (and new method `waitUntilGoalsReady`, which returns a Promise based on that event) indicates when the client has loaded goals-- i.e. when it is possible for pageview events and click events to be triggered.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/src/EventProcessor.js
+++ b/src/EventProcessor.js
@@ -2,6 +2,7 @@ import EventSender from './EventSender';
 import EventSummarizer from './EventSummarizer';
 import UserFilter from './UserFilter';
 import * as errors from './errors';
+import * as messages from './messages';
 import * as utils from './utils';
 
 export default function EventProcessor(eventsUrl, environmentId, options = {}, emitter = null, sender = null) {
@@ -122,11 +123,15 @@ export default function EventProcessor(eventsUrl, environmentId, options = {}, e
         if (responseInfo.serverTime) {
           lastKnownPastTime = responseInfo.serverTime;
         }
-        if (responseInfo.status === 401) {
+        if (!errors.isHttpErrorRecoverable(responseInfo.status)) {
           disabled = true;
+        }
+        if (responseInfo.status >= 400) {
           utils.onNextTick(() => {
             emitter.maybeReportError(
-              new errors.LDUnexpectedResponseError('Received 401 error, no further events will be posted')
+              new errors.LDUnexpectedResponseError(
+                messages.httpErrorMessage(responseInfo.status, 'event posting', 'some events were dropped')
+              )
             );
           });
         }

--- a/src/errors.js
+++ b/src/errors.js
@@ -18,3 +18,10 @@ export const LDInvalidUserError = createCustomError('LaunchDarklyInvalidUserErro
 export const LDInvalidEventKeyError = createCustomError('LaunchDarklyInvalidEventKeyError');
 export const LDInvalidArgumentError = createCustomError('LaunchDarklyInvalidArgumentError');
 export const LDFlagFetchError = createCustomError('LaunchDarklyFlagFetchError');
+
+export function isHttpErrorRecoverable(status) {
+  if (status >= 400 && status < 500) {
+    return status === 408 || status === 429;
+  }
+  return true;
+}

--- a/src/messages.js
+++ b/src/messages.js
@@ -40,3 +40,15 @@ export const invalidUser = function() {
 export const deprecated = function(oldName, newName) {
   return '[LaunchDarkly] "' + oldName + '" is deprecated, please use "' + newName + '"';
 };
+
+export const httpErrorMessage = function(status, context, retryMessage) {
+  return (
+    'Received error ' +
+    status +
+    (status === 401 ? ' (invalid SDK key)' : '') +
+    ' for ' +
+    context +
+    ' - ' +
+    (errors.isHttpErrorRecoverable(status) ? retryMessage : 'giving up permanently')
+  );
+};


### PR DESCRIPTION
## [2.3.0] - 2018-06-26
### Changed:
The client will now stop trying to send analytics events if it receives almost any HTTP 4xx error from LaunchDarkly; such errors indicate either a configuration problem (invalid SDK key) or a bug, which is not likely to resolve without a restart or an upgrade. This does not apply if the error is 400, 408, or 429.
