### PR TITLE
prepare 2.3.1 release

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -441,7 +441,7 @@ function initialize(env, user, options = {}) {
       if (err) {
         emitter.maybeReportError(new errors.LDFlagFetchError(messages.errorFetchingFlags(err)));
       }
-      flags = settings;
+      flags = settings || {};
       emitter.emit(readyEvent);
     });
   }


### PR DESCRIPTION
## [2.3.1] - 2018-06-29
### Fixed:
- If a polling request has failed due to an invalid environment key, calling `variation` now returns the default value; previously, it sometimes caused a null reference error.
