### PR TITLE
prepare 2.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org).
 ### Fixed:
 - The result value of `identify()` (provided by either a promise or a callback, once the flag values for the new user have been retrieved) used to be a simple map of flag keys to values, until it was accidentally changed to an internal data structure in version 2.0.0. It is now a map of flag keys to values again, consistent with what is returned by `allFlags()`.
 - Added TypeScript definitions for the result values of `identify()`. (Thanks, [1999](https://github.com/launchdarkly/js-client/pull/102)!)
+- Documented all optional compatibility polyfills in `README.md`.
 
 ## [2.4.0] - 2018-07-12
 ### Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to the LaunchDarkly client-side JavaScript SDK will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [2.4.1] - 2018-08-14
+### Fixed:
+- The result value of `identify()` (provided by either a promise or a callback, once the flag values for the new user have been retrieved) used to be a simple map of flag keys to values, until it was accidentally changed to an internal data structure in version 2.0.0. It is now a map of flag keys to values again, consistent with what is returned by `allFlags()`.
+- Added TypeScript definitions for the result values of `identify()`. (Thanks, [1999](https://github.com/launchdarkly/js-client/pull/102)!)
+
 ## [2.4.0] - 2018-07-12
 ### Added:
 - Named exports for the `initialize` method and `version` number exports.

--- a/README.md
+++ b/README.md
@@ -28,17 +28,22 @@ when `client.on('change')` is called.
 ### EventSource polyfill
 
 If you need streaming support, and you wish to support browsers that do not
-support `EventSource` natively, you can install a polyfill, such as
+support `EventSource` natively, you can install a polyfill such as
 [EventSource](https://github.com/Yaffle/EventSource).
 
-You can load the polyfill via a script tag in the `<head>` before the script
-where you initialize `LDClient`:
+#### CDN
 
-    <script src="/public/eventsource.js"></script>
+You can load the polyfill via a script tag in the `<head>` before the script where you initialize `LDClient`:
 
-If you use [webpack](https://webpack.github.io/) or
-[browserify](http://browserify.org/), make sure to require the polyfill before
-`LDClient` is initialized.
+    <script src="https://unpkg.com/event-source-polyfill@0.0.12/src/eventsource.min.js"></script>
+
+#### NPM or Yarn
+
+    npm install event-source-polyfill@0.0.12
+
+Then import it before the module that initializes the LaunchDarkly client:
+
+    require('event-source-polyfill');
 
 ### Document.querySelectorAll() polyfill
 
@@ -46,11 +51,39 @@ If you need to run A/B tests on IE7 or IE8 you will need to install a polyfill
 for `document.querySelector()` such as
 [polyfill-queryselector](https://github.com/cobbdb/polyfill-queryselector).
 
-You can load the polyfll via a script tag in the `<head>`:
+#### CDN
 
-    <script src="/public/querySelector.js"></script>
+You can load the polyfill via a script tag in the `<head>` before the script where you initialize `LDClient`:
 
-You can also install it with `npm install polyfill-queryselector` or `bower install polyfill-queryselector`.
+    <script src="https://unpkg.com/polyfill-queryselector@1.0.2/querySelector.js"></script>
+
+#### NPM or Yarn
+
+    npm install polyfill-queryselector@1.0.2
+
+Then import it before the module that initializes the LaunchDarkly client:
+
+    require('polyfill-queryselector');
+
+### Promise polyfill
+
+The newer versions of the use `Promise`. If you need to support older browsers, you will
+need to install a polyfill for it, such as [es6-promise](https://github.com/stefanpenner/es6-promise).
+
+#### CDN
+
+You can load the polyfill via a script tag in the `<head>` before the script where you initialize `LDClient`:
+
+    <script src="https://unpkg.com/es6-promise@4.2.4/dist/es6-promise.auto.min.js"></script>
+
+#### NPM or Yarn
+
+    npm install es6-promise@4.2.4
+
+Then import it before the module that initializes the LaunchDarkly client:
+
+    require('es6-promise/auto');
+
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.1.2",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-js",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "LaunchDarkly SDK for JavaScript",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jest": "22.4.3",
     "jest-junit": "3.6.0",
     "jest-localstorage-mock": "2.2.0",
+    "jsdom": "11.11.0",
     "prettier": "1.11.1",
     "readline-sync": "1.4.9",
     "rimraf": "2.6.2",

--- a/src/__tests__/LDClient-test.js
+++ b/src/__tests__/LDClient-test.js
@@ -896,6 +896,34 @@ describe('LDClient', () => {
       });
     });
 
+    it('updates flag values when the user changes', done => {
+      const user2 = { key: 'user2' };
+      const client = LDClient.initialize(envName, user, { bootstrap: {} });
+
+      client.on('ready', () => {
+        client.identify(user2, null, () => {
+          expect(client.variation('enable-foo')).toEqual(true);
+          done();
+        });
+
+        getLastRequest().respond(200, { 'Content-Type': 'application/json' }, '{"enable-foo": {"value": true}}');
+      });
+    });
+
+    it('yields map of flag values as the result of identify()', done => {
+      const user2 = { key: 'user2' };
+      const client = LDClient.initialize(envName, user, { bootstrap: {} });
+
+      client.on('ready', () => {
+        client.identify(user2, null).then(flagMap => {
+          expect(flagMap).toEqual({ 'enable-foo': true });
+          done();
+        });
+
+        getLastRequest().respond(200, { 'Content-Type': 'application/json' }, '{"enable-foo": {"value": true}}');
+      });
+    });
+
     it('reconnects to stream if the user changes', done => {
       const user2 = { key: 'user2' };
       const encodedUser2 = 'eyJrZXkiOiJ1c2VyMiJ9';
@@ -911,7 +939,7 @@ describe('LDClient', () => {
           done();
         });
 
-        getLastRequest().respond(200, { 'Content-Type': 'application/json' }, '{"enable-foo": true}');
+        getLastRequest().respond(200, { 'Content-Type': 'application/json' }, '{"enable-foo": {"value": true}}');
       });
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,7 @@ export function initialize(env, user, options = {}) {
             if (settings) {
               updateSettings(settings);
             }
-            resolve(settings);
+            resolve(utils.transformVersionedValuesToValues(settings));
             if (subscribedToChangeEvents) {
               connectStream();
             }

--- a/src/utils.js
+++ b/src/utils.js
@@ -77,6 +77,19 @@ export function transformValuesToVersionedValues(flags) {
 }
 
 /**
+ * Converts the internal flag state map to a simple map of flag keys to values.
+ */
+export function transformVersionedValuesToValues(flagsState) {
+  const ret = {};
+  for (const key in flagsState) {
+    if (flagsState.hasOwnProperty(key)) {
+      ret[key] = flagsState[key].value;
+    }
+  }
+  return ret;
+}
+
+/**
  * Returns an array of event groups each of which can be safely URL-encoded
  * without hitting the safe maximum URL length of certain browsers.
  *


### PR DESCRIPTION
## [2.4.1] - 2018-08-14
### Fixed:
- The result value of `identify()` (provided by either a promise or a callback, once the flag values for the new user have been retrieved) used to be a simple map of flag keys to values, until it was accidentally changed to an internal data structure in version 2.0.0. It is now a map of flag keys to values again, consistent with what is returned by `allFlags()`.
- Added TypeScript definitions for the result values of `identify()`. (Thanks, [1999](https://github.com/launchdarkly/js-client/pull/102)!)
- Documented all optional compatibility polyfills in `README.md`.
