### PR TITLE
Export LDReactContext in addition to Provider and Consumer, closes #143

### DIFF
--- a/packages/ldclient-react/src/context.ts
+++ b/packages/ldclient-react/src/context.ts
@@ -4,7 +4,7 @@ import { LDClient, LDFlagSet } from 'ldclient-js';
 /**
  * The LaunchDarkly context stored in the Provider state and passed to consumers.
  */
-interface LDContext {
+export interface LDContext {
   /**
    * Contains all flags from LaunchDarkly. This object will always exist but will be empty {} initially
    * until flags are fetched from the LaunchDarkly servers.
@@ -20,5 +20,6 @@ interface LDContext {
   ldClient?: LDClient;
 }
 
-const { Provider, Consumer } = createContext<LDContext>({ flags: {}, ldClient: undefined });
-export { Provider, Consumer, LDContext };
+export const LDReactContext = createContext<LDContext>({ flags: {}, ldClient: undefined });
+export const Provider = LDReactContext.Provider;
+export const Consumer = LDReactContext.Consumer;

--- a/packages/ldclient-react/src/index.ts
+++ b/packages/ldclient-react/src/index.ts
@@ -1,4 +1,5 @@
+import { LDReactContext } from './context';
 import withLDProvider from './withLDProvider';
 import withLDConsumer from './withLDConsumer';
 
-export { withLDProvider, withLDConsumer };
+export { LDReactContext, withLDProvider, withLDConsumer };


### PR DESCRIPTION
* Enables `useContext` API by exporting non-destructured React Context.
* Non-destructive API change.
* Verified working with given example.

Can't wait to get this released!

```js
import React, { useContext } from 'react';
import { LDReactContext } from 'ldclient-react';

export default function Home() {
  const { flags } = useContext(LDReactContext)
  return (
    <Root>
      <Heading>Welcome to ldclient-react Example App</Heading>
      <div>
        To run this example:
        <ul>
          <ListItem>
            In app.js, set clientSideID to your own Client-side ID. You can find this in your ld portal under Account
            settings / Projects.
          </ListItem>
          <ListItem>
            Create a flag called dev-test-flag in your project. Make sure you make it available for the client side js
            sdk.
          </ListItem>
          <ListItem>Turn the flag on and off to see this app respond without a browser refresh.</ListItem>
        </ul>
      </div>
      <FlagDisplay>{flags.devTestFlag ? <FlagOn>Flag on</FlagOn> : <span>Flag off</span>}</FlagDisplay>
    </Root>
  );
}
```