### PR TITLE
prepare 2.9.6 release

### DIFF
--- a/packages/ldclient-js-common/src/EventSender.js
+++ b/packages/ldclient-js-common/src/EventSender.js
@@ -75,6 +75,10 @@ export default function EventSender(platform, eventsUrl, environmentId, imageCre
     if (!platform.newHttpRequest) {
       return Promise.resolve();
     }
+    // Workaround for non-support of sync XHR in some browsers - https://github.com/launchdarkly/js-client/issues/147
+    if (sync && !(platform.httpAllowsSync && platform.httpAllowsSync())) {
+      return Promise.resolve();
+    }
     const canPost = platform.httpAllowsPost();
     const finalSync = sync === undefined ? false : sync;
     let chunks;

--- a/packages/ldclient-js-common/src/__tests__/EventSender-test.js
+++ b/packages/ldclient-js-common/src/__tests__/EventSender-test.js
@@ -122,6 +122,15 @@ describe('EventSender', () => {
       expect(lastRequest().async).toEqual(false);
     });
 
+    it('should skip synchronous request if not supported', () => {
+      const noSyncPlatform = stubPlatform.defaults();
+      noSyncPlatform.httpAllowsSync = () => false;
+      const sender = EventSender(noSyncPlatform, eventsUrl, envId);
+      const event = { kind: 'identify', key: 'userKey' };
+      sender.sendEvents([event], true);
+      expect(requests.length).toEqual(0);
+    });
+
     it('should send all events in request body', () => {
       const sender = EventSender(platform, eventsUrl, envId);
       const events = [];

--- a/packages/ldclient-js-common/src/__tests__/stubPlatform.js
+++ b/packages/ldclient-js-common/src/__tests__/stubPlatform.js
@@ -14,6 +14,7 @@ export function defaults() {
   const p = {
     newHttpRequest: () => new sinonXhr(),
     httpAllowsPost: () => true,
+    httpAllowsSync: () => true,
     getCurrentUrl: () => currentUrl,
     isDoNotTrack: () => doNotTrack,
     eventSourceFactory: (url, options) => {

--- a/packages/ldclient-js/src/__tests__/browserPlatform-test.js
+++ b/packages/ldclient-js/src/__tests__/browserPlatform-test.js
@@ -4,6 +4,44 @@ describe('browserPlatform', () => {
   const platform = browserPlatform();
   const lsKeyPrefix = 'ldclient-js-test:';
 
+  describe('httpAllowsSync()', () => {
+    function platformWithUserAgent(s) {
+      window.navigator.__defineGetter__('userAgent', () => s);
+      return browserPlatform();
+    }
+
+    it('returns true for Chrome 72', () => {
+      const p = platformWithUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36'
+      );
+      expect(p.httpAllowsSync()).toBe(true);
+    });
+
+    it('returns false for Chrome 73', () => {
+      const p = platformWithUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.103 Safari/537.36'
+      );
+      expect(p.httpAllowsSync()).toBe(false);
+    });
+
+    it('returns false for Chrome 74', () => {
+      const p = platformWithUserAgent(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3683.103 Safari/537.36'
+      );
+      expect(p.httpAllowsSync()).toBe(false);
+    });
+
+    it('returns true for unknown browser', () => {
+      const p = platformWithUserAgent('Special Kitty Cat Browser');
+      expect(p.httpAllowsSync()).toBe(true);
+    });
+
+    it('returns true if userAgent is missing', () => {
+      const p = platformWithUserAgent(null);
+      expect(p.httpAllowsSync()).toBe(true);
+    });
+  });
+
   describe('getCurrentUrl()', () => {
     it('returns value of window.location.href', () => {
       expect(platform.getCurrentUrl()).toEqual(window.location.href);

--- a/packages/ldclient-js/src/browserPlatform.js
+++ b/packages/ldclient-js/src/browserPlatform.js
@@ -15,6 +15,9 @@ export default function makeBrowserPlatform() {
     return hasCors;
   };
 
+  const allowsSync = isSyncXhrSupported();
+  ret.httpAllowsSync = () => allowsSync;
+
   ret.getCurrentUrl = () => window.location.href;
 
   ret.isDoNotTrack = () => {
@@ -89,4 +92,18 @@ export default function makeBrowserPlatform() {
   ret.userAgent = 'JSClient';
 
   return ret;
+}
+
+// This is temporary logic to disable synchronous XHR in Chrome 73 and above. In all other browsers,
+// we will assume it is supported. See https://github.com/launchdarkly/js-client/issues/147
+function isSyncXhrSupported() {
+  const userAgent = window.navigator && window.navigator.userAgent;
+  if (userAgent) {
+    const chromeMatch = userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    if (chromeMatch) {
+      const version = parseInt(chromeMatch[2], 10);
+      return version < 73;
+    }
+  }
+  return true;
 }


### PR DESCRIPTION
## [2.9.6] - 2019-04-16
### Fixed:
- If there are pending analytics events when the page is being closed, the SDK normally attempts to deliver them by making a synchronous HTTP request. Chrome, as of version 73, does not allow this and logs an error. An upcoming release will change how events are sent, but as a temporary measure to avoid these errors, the SDK will now simply discard any pending events when the page is being closed _if_ the browser is Chrome version 73 or higher. In other browsers, there is no change. Note that this means that in Chrome 73, some events may be lost; that was already the case. The purpose of this patch is simply to avoid triggering errors. ([#178](https://github.com/launchdarkly/js-client-private/pull/178))